### PR TITLE
enable rsync__exclude option for synced_folder

### DIFF
--- a/lib/vagrant-digitalocean/actions/sync_folders.rb
+++ b/lib/vagrant-digitalocean/actions/sync_folders.rb
@@ -47,12 +47,17 @@ module VagrantPlugins
 						key = ssh_info[:private_key_path]
 						key = key[0] if key.is_a?(Array)
 
+            # build exclude rules
+            excludes = ['.vagrant/']
+            excludes += Array(data[:rsync__exclude]).map(&:to_s) if data[:rsync__exclude]
+            excludes.uniq!
+
             # rsync over to the guest path using the ssh info
             command = [
-              "rsync", "--verbose", "--archive", "-z", "--delete",
+              "rsync", "--verbose", "--archive", "-z", "--delete", excludes.map { |e| "--exclude=#{e}" },
               "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{key}'",
               hostpath,
-              "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
+              "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"].flatten
 
 						# we need to fix permissions when using rsync.exe on windows, see
 					  # http://stackoverflow.com/questions/5798807/rsync-permission-denied-created-directories-have-no-permissions

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,6 +8,8 @@ Vagrant.configure('2') do |config|
   config.ssh.private_key_path = 'test_id_rsa'
 
   config.vm.synced_folder '.', '/vagrant', :disabled => true
+  config.vm.synced_folder '.', '/tmp/test', type: "rsync",
+    rsync__exclude: ['cookbooks/', 'scripts/']
 
   config.vm.provider :digital_ocean do |provider, override|
     override.vm.box = 'digital_ocean'
@@ -26,7 +28,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :ubuntu do |ubuntu|
     ubuntu.vm.provider :digital_ocean do |provider|
-      provider.image = 'Ubuntu 12.04.3 x64'
+      provider.image = 'Ubuntu 12.04.4 x64'
     end
   end
 


### PR DESCRIPTION
I want to be able to specify the exclude in synced_folder at Vagrantfile.

It is compatible with vagrant api version 2 .