### PR TITLE
Shutdown droplets by default. Support poweroff with vagrant halt -f.

### DIFF
--- a/lib/vagrant-digitalocean/actions.rb
+++ b/lib/vagrant-digitalocean/actions.rb
@@ -1,6 +1,7 @@
 require 'vagrant-digitalocean/actions/check_state'
 require 'vagrant-digitalocean/actions/create'
 require 'vagrant-digitalocean/actions/destroy'
+require 'vagrant-digitalocean/actions/shut_down'
 require 'vagrant-digitalocean/actions/power_off'
 require 'vagrant-digitalocean/actions/power_on'
 require 'vagrant-digitalocean/actions/rebuild'
@@ -112,7 +113,11 @@ module VagrantPlugins
           builder.use Call, CheckState do |env, b|
             case env[:machine_state]
             when :active
-              b.use PowerOff
+              if env[:force_halt] 
+                b.use PowerOff
+              else
+                b.use ShutDown
+              end
             when :off
               env[:ui].info I18n.t('vagrant_digital_ocean.info.already_off')
             when :not_created

--- a/lib/vagrant-digitalocean/actions/shut_down.rb
+++ b/lib/vagrant-digitalocean/actions/shut_down.rb
@@ -1,0 +1,33 @@
+require 'vagrant-digitalocean/helpers/client'
+
+module VagrantPlugins
+  module DigitalOcean
+    module Actions
+      class ShutDown
+        include Helpers::Client
+
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+          @client = client
+          @logger = Log4r::Logger.new('vagrant::digitalocean::shut_down')
+        end
+
+        def call(env)
+          # submit shutdown droplet request
+          result = @client.request("/droplets/#{@machine.id}/shutdown")
+
+          # wait for request to complete
+          env[:ui].info I18n.t('vagrant_digital_ocean.info.shutting_down')
+          @client.wait_for_event(env, result['event_id'])
+
+          # refresh droplet state with provider
+          Provider.droplet(@machine, :refresh => true)
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end
+

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,6 +9,7 @@ en:
       droplet_ip: "Assigned IP address: %{ip}"
       droplet_private_ip: "Private IP address: %{ip}"
       destroying: "Destroying the droplet..."
+      shutting_down: "Shutting down the droplet..."
       powering_off: "Powering off the droplet..."
       powering_on: "Powering on the droplet..."
       rebuilding: "Rebuilding the droplet..."


### PR DESCRIPTION
This patch uses the 'shutdown' action rather than poweroff when using vagrant halt, as i think would be expected by the user.

This also fixes an inconsistency where the "reboot" action performs a graceful restart, while "halt" powers off.