### PR TITLE
replace `Defaults\ *requiretty` to `Defaults:vagrant \!requiretty`.

### DIFF
--- a/lib/vagrant-digitalocean/actions/sync_folders.rb
+++ b/lib/vagrant-digitalocean/actions/sync_folders.rb
@@ -18,6 +18,12 @@ module VagrantPlugins
             next if data[:disabled]
 
             if @machine.guest.capability?(:rsync_installed)
+
+              # XXX: changed the sudoers without using visudo.
+              @machine.communicate.tap do |comm|
+                comm.execute('cp /etc/sudoers /etc/sudoers.backup; cat /etc/sudoers | sed -e "s/Defaults\ *requiretty/Defaults:vagrant \!requiretty/"  > /etc/_sudoers; mv /etc/_sudoers /etc/sudoers', {})
+              end
+
               installed = @machine.guest.capability(:rsync_installed)
               if !installed
                 can_install = @machine.guest.capability?(:rsync_install)


### PR DESCRIPTION
I failed `vagrant provision` in the following environments.
```
Droplet info:
region: San Francisco 1
os: CentOS 7.0 x64
```

Failed logs:
```
$ vagrant provision
==> default: Installing rsync to the VM...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

yum -y install rsync

Stdout from the command:



Stderr from the command:

sudo: sorry, you must have a tty to run sudo
```

"Defaults requiretty" in "/etc/sudoers" is cause. so I wrote patch.
but, I think this patch is too bad solution. X(
because
- edit /etc/sudoers
- I don't know this problem occurs only in other OS.

I want to know if there is a better solution.

My Vagrantfile:
```ruby
Vagrant.configure('2') do |config|
  config.vm.hostname = '...'

  config.vm.provider :digital_ocean do |provider, override|
    override.ssh.username         = "root"
    override.ssh.private_key_path = '~/.ssh/id_rsa'
    override.vm.box               = 'digital_ocean'
    override.vm.box_url           = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"


    provider.client_id    = '...'
    provider.api_key      = '...'
    provider.token        = '...'
  end
end
```

Will succeed if patched.
```
 $ vagrant provision
==> default: Installing rsync to the VM...
==> default: Rsyncing folder: /Users/hisaichi5518/project/demo/ => /vagrant...
```
