### PR TITLE
Remove keys with nil value from the hash #167

### DIFF
--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
             :backups => @machine.provider_config.backups_enabled,
             :ipv6 => @machine.provider_config.ipv6,
             :user_data => @machine.provider_config.user_data
-          })
+          }.delete_if { |k, v| v.nil? })
 
           # wait for request to complete
           env[:ui].info I18n.t('vagrant_digital_ocean.info.creating')


### PR DESCRIPTION
Regarding to DO documentation droplet creation [1] , attributes that can be null are not required in the request body which means that removing them from the payload is OK.
This will workaround issue #167  

[1] https://developers.digitalocean.com/#create-a-new-droplet