### PR TITLE
fixes #180: chown the user's .ssh directory after creation of authorized_keys

### DIFF
--- a/lib/vagrant-digitalocean/actions/setup_user.rb
+++ b/lib/vagrant-digitalocean/actions/setup_user.rb
@@ -50,6 +50,7 @@ module VagrantPlugins
           @machine.communicate.execute(<<-BASH)
             if ! grep '#{pub_key}' /home/#{user}/.ssh/authorized_keys; then
               echo '#{pub_key}' >> /home/#{user}/.ssh/authorized_keys;
+              chown -R #{user} /home/#{user}/.ssh;
             fi
           BASH
 

--- a/lib/vagrant-digitalocean/actions/setup_user.rb
+++ b/lib/vagrant-digitalocean/actions/setup_user.rb
@@ -50,8 +50,9 @@ module VagrantPlugins
           @machine.communicate.execute(<<-BASH)
             if ! grep '#{pub_key}' /home/#{user}/.ssh/authorized_keys; then
               echo '#{pub_key}' >> /home/#{user}/.ssh/authorized_keys;
-              chown -R #{user} /home/#{user}/.ssh;
             fi
+
+            chown -R #{user} /home/#{user}/.ssh;
           BASH
 
           # reset username


### PR DESCRIPTION
I've excluded changing the group away from root because it involves adding a somewhat substantial amount of platform-specific probing to figure out the right group with which to chown `~/.ssh`. This should fix the immediate issue.