### PR TITLE
Adding support for root users that are not named 'root'. For example CoreOS root username is 'core' not 'root'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+Contribution:
+=============
+
+Adding support for root users that are not named 'root'. 
+For example CoreOS root username is 'core' not 'root'.
+
+For changing the default 'root' username use .root_username attribute.
+                                             -------------- 
+Example:
+
+  config.vm.provider :digital_ocean do |provider, override|
+    override.ssh.private_key_path = '~/.ssh/id_rsa'
+    override.vm.box = 'digital_ocean'
+    override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+
+    provider.token = 'YOUR TOKEN'
+    provider.image = 'ubuntu-14-04-x64'
+    provider.region = 'nyc2'
+    provider.size = '512mb'
+    privider.root_username = 'core'
+    -------------------------------
+  end
+
 Digital Ocean Vagrant Provider
 ==============================
 `vagrant-digitalocean` is a provider plugin for Vagrant that supports the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Adding support for root users that are not named 'root'.
 For example CoreOS root username is 'core' not 'root'.
 
 For changing the default 'root' username use .root_username attribute.
-                                             -------------- 
+
 Example:
 
   config.vm.provider :digital_ocean do |provider, override|
@@ -18,7 +18,6 @@ Example:
     provider.region = 'nyc2'
     provider.size = '512mb'
     privider.root_username = 'core'
-    -------------------------------
   end
 
 Digital Ocean Vagrant Provider

--- a/README.md
+++ b/README.md
@@ -8,17 +8,12 @@ For changing the default 'root' username use .root_username attribute.
 
 Example:
 
-  config.vm.provider :digital_ocean do |provider, override|
-    override.ssh.private_key_path = '~/.ssh/id_rsa'
-    override.vm.box = 'digital_ocean'
-    override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
-
     provider.token = 'YOUR TOKEN'
     provider.image = 'ubuntu-14-04-x64'
     provider.region = 'nyc2'
     provider.size = '512mb'
     privider.root_username = 'core'
-  end
+
 
 Digital Ocean Vagrant Provider
 ==============================

--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -57,7 +57,7 @@ module VagrantPlugins
           # wait for ssh to be ready
           switch_user = @machine.provider_config.setup?
           user = @machine.config.ssh.username
-          @machine.config.ssh.username = 'root' if switch_user
+          @machine.config.ssh.username = @machine.provider_config.root_username if switch_user
 
           retryable(:tries => 120, :sleep => 10) do
             next if env[:interrupted]

--- a/lib/vagrant-digitalocean/actions/rebuild.rb
+++ b/lib/vagrant-digitalocean/actions/rebuild.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
           # wait for ssh to be ready
           switch_user = @machine.provider_config.setup?
           user = @machine.config.ssh.username
-          @machine.config.ssh.username = 'root' if switch_user
+          @machine.config.ssh.username = @machine.provider_config.root_username if switch_user
 
           retryable(:tries => 120, :sleep => 10) do
             next if env[:interrupted]

--- a/lib/vagrant-digitalocean/actions/setup_sudo.rb
+++ b/lib/vagrant-digitalocean/actions/setup_sudo.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
 
           # override ssh username to root
           user = @machine.config.ssh.username
-          @machine.config.ssh.username = 'root'
+          @machine.config.ssh.username = @machine.provider_config.root_username
 
           # check for guest name available in Vagrant 1.2 first
           guest_name = @machine.guest.name if @machine.guest.respond_to?(:name)

--- a/lib/vagrant-digitalocean/actions/setup_user.rb
+++ b/lib/vagrant-digitalocean/actions/setup_user.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
 
           # override ssh username to root temporarily
           user = @machine.config.ssh.username
-          @machine.config.ssh.username = 'root'
+          @machine.config.ssh.username = @machine.provider_config.root_username
 
           env[:ui].info I18n.t('vagrant_digital_ocean.info.creating_user', {
             :user => user

--- a/lib/vagrant-digitalocean/config.rb
+++ b/lib/vagrant-digitalocean/config.rb
@@ -12,6 +12,7 @@ module VagrantPlugins
       attr_accessor :ssh_key_name
       attr_accessor :setup
       attr_accessor :user_data
+      attr_accessor :root_username
 
       alias_method :setup?, :setup
 
@@ -27,6 +28,7 @@ module VagrantPlugins
         @ssh_key_name       = UNSET_VALUE
         @setup              = UNSET_VALUE
         @user_data          = UNSET_VALUE
+        @root_username      = UNSET_VALUE
       end
 
       def finalize!
@@ -41,6 +43,7 @@ module VagrantPlugins
         @ssh_key_name       = 'Vagrant' if @ssh_key_name == UNSET_VALUE
         @setup              = true if @setup == UNSET_VALUE
         @user_data          = nil if @user_data == UNSET_VALUE
+        @root_username      = 'root' if @root_username == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-digitalocean/provider.rb
+++ b/lib/vagrant-digitalocean/provider.rb
@@ -84,7 +84,7 @@ module VagrantPlugins
         return {
           :host => public_network['ip_address'],
           :port => '22',
-          :username => 'root',
+          :username => @machine.provider_config.root_username,
           :private_key_path => nil
         }
       end

--- a/lib/vagrant-digitalocean/version.rb
+++ b/lib/vagrant-digitalocean/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module DigitalOcean
-    VERSION = '0.7.3'
+    VERSION = '0.7.4'
   end
 end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -34,4 +34,11 @@ Vagrant.configure('2') do |config|
       provider.image = 'centos-6-5-x64'
     end
   end
+  
+  config.vm.define :coreos do |centos|
+    centos.vm.provider :digital_ocean do |provider|
+      provider.image = 'coreos-alpha'
+      provider.root_username = 'core'
+    end
+  end
 end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -35,8 +35,8 @@ Vagrant.configure('2') do |config|
     end
   end
   
-  config.vm.define :coreos do |centos|
-    centos.vm.provider :digital_ocean do |provider|
+  config.vm.define :coreos do |coreos|
+    coreos.vm.provider :digital_ocean do |provider|
       provider.image = 'coreos-alpha'
       provider.root_username = 'core'
     end


### PR DESCRIPTION
For changing the default 'root' username use .root_username attribute.

Example:

provider.token = 'YOUR TOKEN'
provider.image = 'ubuntu-14-04-x64'
provider.region = 'nyc2'
provider.size = '512mb'
privider.root_username = 'core'