### PR TITLE
Added support for passing the token using environment variable to list commands. Added support for use of image ids rather than slugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ vagrant digitalocean-list regions $DIGITAL_OCEAN_TOKEN
 vagrant digitalocean-list sizes $DIGITAL_OCEAN_TOKEN
 ```
 
-You can as well eliminate the need to enter the token manually by setting the `DIGITAL_OCEAN_TOKEN` environment variable.
+You can as well eliminate the need to enter the token manually by setting the `DO_TOKEN` environment variable.
 
 Run
 ---

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ vagrant digitalocean-list regions $DIGITAL_OCEAN_TOKEN
 vagrant digitalocean-list sizes $DIGITAL_OCEAN_TOKEN
 ```
 
+You can as well eliminate the need to enter the token manually by setting the `DIGITAL_OCEAN_TOKEN` environment variable.
+
 Run
 ---
 After creating your project's `Vagrantfile` with the required configuration

--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -17,15 +17,11 @@ module VagrantPlugins
         def call(env)
           ssh_key_id = [env[:ssh_key_id]]
 
-          image_id = @client
-            .request('/v2/images')
-            .find_id(:images, :slug => @machine.provider_config.image)
-
           # submit new droplet request
           result = @client.post('/v2/droplets', {
             :size => @machine.provider_config.size,
             :region => @machine.provider_config.region,
-            :image => image_id,
+            :image => @machine.provider_config.image,
             :name => @machine.config.vm.hostname || @machine.name,
             :ssh_keys => ssh_key_id,
             :private_networking => @machine.provider_config.private_networking,

--- a/lib/vagrant-digitalocean/commands/list.rb
+++ b/lib/vagrant-digitalocean/commands/list.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
 
         def execute
           @token = nil
+          id = false
 
           @opts = OptionParser.new do |o|
             o.banner = 'Usage: vagrant digitalocean-list [options] <images|regions|sizes> <token>'
@@ -18,6 +19,11 @@ module VagrantPlugins
             o.on("-r", "--[no-]regions", "show the regions when listing images") do |r|
               @regions = r
             end
+
+            o.on("-i", "--ids", "show image ids in addition to image slugs") do |i|
+              id = true
+            end
+
           end
 
           argv = parse_options(@opts)
@@ -34,12 +40,14 @@ module VagrantPlugins
             images = Array(result["images"])
             if @regions
               images_table = images.map do |image|
-                '%-50s %-30s %-50s' % ["#{image['distribution']} #{image['name']}", image['slug'], image['regions'].join(', ')]
+                identifier = id ? "#{image['slug']} (#{image['id']})" : image['slug']
+                '%-50s %-30s %-50s' % ["#{image['distribution']} #{image['name']}", identifier, image['regions'].join(', ')]
               end
               @env.ui.info I18n.t('vagrant_digital_ocean.info.images_with_regions', images: images_table.sort.join("\r\n"))
             else
               images_table = images.map do |image|
-                '%-50s %-30s' % ["#{image['distribution']} #{image['name']}", image['slug']]
+                identifier = id ? "#{image['slug']} (#{image['id']})" : image['slug']
+                '%-50s %-30s' % ["#{image['distribution']} #{image['name']}", identifier]
               end
               @env.ui.info I18n.t('vagrant_digital_ocean.info.images', images: images_table.sort.join("\r\n"))
             end

--- a/lib/vagrant-digitalocean/commands/list.rb
+++ b/lib/vagrant-digitalocean/commands/list.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
           end
 
           argv = parse_options(@opts)
-          @token = argv[1]
+          @token = argv[0].nil? ? ENV['DIGITAL_OCEAN_TOKEN'] : argv[0]
 
           if @token.nil?
             usage

--- a/lib/vagrant-digitalocean/commands/list.rb
+++ b/lib/vagrant-digitalocean/commands/list.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
           end
 
           argv = parse_options(@opts)
-          @token = argv[0].nil? ? ENV['DIGITAL_OCEAN_TOKEN'] : argv[0]
+          @token = argv[1].nil? ? ENV['DO_TOKEN'] : argv[1]
 
           if @token.nil?
             usage


### PR DESCRIPTION
Instead of passing the token to the list commands in command line, now you can store the token in an environment variable and use the list commands freely. Added support for listing image ids and launching images by id (This is necessary for launching VMs based on private images).