### PR TITLE
Allow creates with user generated snapshots.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Please note the following:
 **Supported Configuration Attributes**
 
 The following attributes are available to further configure the provider:
-- `provider.image` - A string representing the image to use when creating a new droplet. It defaults to `ubuntu-14-04-x64`. List available images with the `digitalocean-list images` command.
+- `provider.image` - A string representing the image to use when creating a new
+   droplet. It defaults to `ubuntu-14-04-x64`. List available images with the
+   `digitalocean-list images` command. Like when using the DigitalOcean API
+   directly, [it can be an image ID or slug](https://developers.digitalocean.com/documentation/v2/#create-a-new-droplet).
 - `provider.ipv6` - A boolean flag indicating whether to enable IPv6
 - `provider.region` - A string representing the region to create the new droplet in. It defaults to `nyc2`. List available regions with the `digitalocean-list regions` command.
 - `provider.size` - A string representing the size to use when creating a

--- a/lib/vagrant-digitalocean/actions/create.rb
+++ b/lib/vagrant-digitalocean/actions/create.rb
@@ -17,15 +17,11 @@ module VagrantPlugins
         def call(env)
           ssh_key_id = [env[:ssh_key_id]]
 
-          image_id = @client
-            .request('/v2/images')
-            .find_id(:images, :slug => @machine.provider_config.image)
-
           # submit new droplet request
           result = @client.post('/v2/droplets', {
             :size => @machine.provider_config.size,
             :region => @machine.provider_config.region,
-            :image => image_id,
+            :image => @machine.provider_config.image,
             :name => @machine.config.vm.hostname || @machine.name,
             :ssh_keys => ssh_key_id,
             :private_networking => @machine.provider_config.private_networking,

--- a/lib/vagrant-digitalocean/commands/list.rb
+++ b/lib/vagrant-digitalocean/commands/list.rb
@@ -34,12 +34,12 @@ module VagrantPlugins
             images = Array(result["images"])
             if @regions
               images_table = images.map do |image|
-                '%-50s %-30s %-50s' % ["#{image['distribution']} #{image['name']}", image['slug'], image['regions'].join(', ')]
+                '%-50s %-20s %-20s %-50s' % ["#{image['distribution']} #{image['name']}", image['slug'], image['id'], image['regions'].join(', ')]
               end
               @env.ui.info I18n.t('vagrant_digital_ocean.info.images_with_regions', images: images_table.sort.join("\r\n"))
             else
               images_table = images.map do |image|
-                '%-50s %-30s' % ["#{image['distribution']} #{image['name']}", image['slug']]
+                '%-50s %-30s %-30s' % ["#{image['distribution']} #{image['name']}", image['slug'], image['id']]
               end
               @env.ui.info I18n.t('vagrant_digital_ocean.info.images', images: images_table.sort.join("\r\n"))
             end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -20,8 +20,8 @@ en:
       trying_rsync_install: "Rsync not found, attempting to install with yum..."
       rsyncing: "Rsyncing folder: %{hostpath} => %{guestpath}..."
       rsync_missing: "The rsync executable was not found in the current path."
-      images: "Description                                        Slug\n\n%{images}"
-      images_with_regions: "Description                                        Slug                           Regions\n\n%{images}"
+      images: "Description                                        Slug                           ID\n\n%{images}"
+      images_with_regions: "Description                                        Slug                 ID                 Regions\n\n%{images}"
       regions: "Description                    Slug\n\n%{regions}"
       sizes: "Memory          CPUs            Slug\n\n%{sizes}"
       list_error: 'Could not contact the Digital Ocean API: %{message}'


### PR DESCRIPTION
Currently, `provider.image` can only be an image slug. This prevents the usage of user generated snapshots. There are a number of related issues:

https://github.com/smdahlen/vagrant-digitalocean/issues/187
https://github.com/smdahlen/vagrant-digitalocean/issues/173
https://github.com/smdahlen/vagrant-digitalocean/pull/185
https://github.com/smdahlen/vagrant-digitalocean/issues/168
https://github.com/smdahlen/vagrant-digitalocean/issues/173

I'd argue to get rid of the image look up all together. It's a very expensive call and can take quite awhile if you have many images on your account. The API already returns a very clear error message if the image doesn't exist:

```
The response status from the API was:

Status: 422
Response: {"id"=>"unprocessable_entity", "message"=>"You specified an invalid image for Droplet creation."}
```

I also think following the API as closely as possible makes the most sense. Trying to find an images ID based on its name will not necessarily work as there is no guarantee two images won't have identical names. The API can accept a slug or an ID, so the best approach is to do the same here.

Thoughts? @skottler?