### PR TITLE
api response comes back with "ssh_keys" in response json

### DIFF
--- a/lib/vagrant-digitalocean/helpers/client.rb
+++ b/lib/vagrant-digitalocean/helpers/client.rb
@@ -63,6 +63,7 @@ module VagrantPlugins
                 new_path = path.split("?")[0]
                 next_result = self.request("#{new_path}?#{uri.query}")
                 req_target = new_path.split("/")[-1]
+                req_target = "ssh_keys" if req_target == "keys"
                 body["#{req_target}"].concat(next_result["#{req_target}"])
               end
             rescue JSON::ParserError => e


### PR DESCRIPTION
The digital ocean api returns a response like:

```json
{
  "ssh_keys": [
    {
      "id": 512189,
      "fingerprint": "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa",
      "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example",
      "name": "My SSH Public Key"
    }
  ],
  "links": {
  },
  "meta": {
    "total": 1
  }
}
```

The previous implementation tried to access the "keys" in the JSON
response, which was nil. It then called concat on nil, resulting in a
no method error. Instead it expected an array, which was under the
"ssh_keys" key.

fixes #220