### PR TITLE
Provide late sudo install on DO's debian-8 image

### DIFF
--- a/lib/vagrant-digitalocean/actions/setup_sudo.rb
+++ b/lib/vagrant-digitalocean/actions/setup_sudo.rb
@@ -21,6 +21,13 @@ module VagrantPlugins
           guest_name ||= @machine.guest.to_s.downcase
 
           case guest_name
+          when /debian/
+            if @machine.provider_config.image =~ /^debian-8/
+              @logger.info "DigitalOcean's debian-8 image lacks sudo. Installing now."
+              @machine.communicate.execute(<<-'BASH')
+                if [ ! -x /usr/bin/sudo ] ; then apt-get update -y && apt-get install -y sudo ; fi
+              BASH
+            end
           when /redhat/
             env[:ui].info I18n.t('vagrant_digital_ocean.info.modifying_sudo')
 

--- a/lib/vagrant-digitalocean/actions/setup_sudo.rb
+++ b/lib/vagrant-digitalocean/actions/setup_sudo.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
           case guest_name
           when /debian/
             if @machine.provider_config.image =~ /^debian-8/
-              @logger.info "DigitalOcean's debian-8 image lacks sudo. Installing now."
+              @logger.info I18n.t('vagrant_digital_ocean.info.late_sudo_install_deb8')
               @machine.communicate.execute(<<-'BASH')
                 if [ ! -x /usr/bin/sudo ] ; then apt-get update -y && apt-get install -y sudo ; fi
               BASH

--- a/lib/vagrant-digitalocean/actions/setup_sudo.rb
+++ b/lib/vagrant-digitalocean/actions/setup_sudo.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
           case guest_name
           when /debian/
             if @machine.provider_config.image =~ /^debian-8/
-              @logger.info I18n.t('vagrant_digital_ocean.info.late_sudo_install_deb8')
+              env[:ui].info I18n.t('vagrant_digital_ocean.info.late_sudo_install_deb8')
               @machine.communicate.execute(<<-'BASH')
                 if [ ! -x /usr/bin/sudo ] ; then apt-get update -y && apt-get install -y sudo ; fi
               BASH

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -15,6 +15,7 @@ en:
       rebuilding: "Rebuilding the droplet..."
       reloading: "Rebooting the droplet..."
       creating_user: "Creating user account: %{user}..."
+      late_sudo_install_deb8:  "DigitalOcean's debian-8 image lacks sudo. Installing now."
       modifying_sudo: "Modifying sudoers file to remove tty requirement..."
       using_key: "Using existing SSH key: %{name}"
       creating_key: "Creating new SSH key: %{name}..."


### PR DESCRIPTION
Various issues (as far as I can see #203 and #109) report a missing sudo on
DigitalOceans debian8 images. We're providing a late installation on vagrant up
which should fix these issues.